### PR TITLE
Fixes incorrect pod identifier in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ To integrate SignalR-Swift into your Xcode project using CocoaPods, specify it i
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
-pod 'SignalR-Swift', '~> 1.0.1'
-```
+pod 'SignalRSwift', '~> 1.0.3'
+ ```
 
 Then, run the following command:
 


### PR DESCRIPTION
Following your [podspec](https://github.com/AutosoftDMS/SignalR-Swift/blob/master/SignalRSwift.podspec), I updated the project's `README.md`

