### PR TITLE
method invoke(method:withArgs:completionHandler:) in HubProxy class is public

### DIFF
--- a/SignalR-Swift/Client/Hubs/HubProxy.swift
+++ b/SignalR-Swift/Client/Hubs/HubProxy.swift
@@ -53,7 +53,7 @@ public class HubProxy: HubProxyProtocol {
         self.invoke(method: method, withArgs: args, completionHandler: nil)
     }
 
-    func invoke(method: String?, withArgs args: [Any], completionHandler: ((Any?, Error?) -> ())?) {
+    public func invoke(method: String?, withArgs args: [Any], completionHandler: ((Any?, Error?) -> ())?) {
         guard method != nil && !method!.isEmpty else {
             NSException.raise(.invalidArgumentException, format: NSLocalizedString("Argument method is null", comment: "null event name exception"), arguments: getVaList(["nil"]))
             return


### PR DESCRIPTION
I use SignalR-ObjC library in my chat application. I want to use SignalR-Swift library written in Swift instead.
There is a problem in this library: I can't invoke an event on my Server-side and get a response (via callback) with data from the Server-side. SignalR-ObjC provides that functionality.