### PR TITLE
type of 'HubResult.result' property is Any?

### DIFF
--- a/SignalR-Swift/Client/Connection.swift
+++ b/SignalR-Swift/Client/Connection.swift
@@ -326,7 +326,7 @@ public class Connection: ConnectionProtocol {
 
     // MARK: - Prepare Request
 
-    func addValue(value: String, forHttpHeaderField field: String) {
+    public func addValue(value: String, forHttpHeaderField field: String) {
         self.headers[field] = value
     }
 

--- a/SignalR-Swift/Client/Hubs/HubResult.swift
+++ b/SignalR-Swift/Client/Hubs/HubResult.swift
@@ -20,7 +20,7 @@ public class HubResult: Mappable {
 
     var id: String?
 
-    var result: String?
+    var result: Any?
     var hubException = false
     var error: String?
 


### PR DESCRIPTION
In the current implementation, if a Server returns to a Client a JSON object or an array of objects the data will be missed.