### PR TITLE
podspec "Alamofire", "~> 4.2"

### DIFF
--- a/SignalRSwift.podspec
+++ b/SignalRSwift.podspec
@@ -64,7 +64,7 @@ Pod::Spec.new do |s|
   s.source_files  = "SignalR-Swift/**/*.swift"
   s.exclude_files = "Classes/Exclude"
 
-  s.dependency "Alamofire", "~> 4.2.0"
+  s.dependency "Alamofire", "~> 4.2"
   s.dependency "SwiftWebSocket"
   s.dependency "AlamofireObjectMapper", "~> 4.0"
 


### PR DESCRIPTION
Based on [documentation](https://guides.cocoapods.org/syntax/podfile.html#pod) if a dependency's version is "~> 4.2.0" then available versions are 4.2.0 and the versions up to 4.3, not including 4.3  