### PR TITLE
a self-signed SSL certificate support

### DIFF
--- a/SignalR-Swift/Client/Connection.swift
+++ b/SignalR-Swift/Client/Connection.swift
@@ -44,6 +44,8 @@ public class Connection: ConnectionProtocol {
 
     public var headers = HTTPHeaders()
     public var keepAliveData: KeepAliveData?
+    public var webSocketAllowsSelfSignedSSL = false
+    public internal(set) var sessionManager: SessionManager
 
     public var transport: ClientTransportProtocol?
     public var transportConnectTimeout = 0.0
@@ -79,14 +81,10 @@ public class Connection: ConnectionProtocol {
         return connection!.state == .reconnecting
     }
 
-    public init(withUrl url: String) {
-        self.url = url.hasSuffix("/") ? url : url.appending("/")
-        self.queryString = nil
-    }
-
-    public init(withUrl url: String, queryString: [String: String]?) {
+    public init(withUrl url: String, queryString: [String: String]? = nil, sessionManager: SessionManager = .default) {
         self.url = url.hasSuffix("/") ? url : url.appending("/")
         self.queryString = queryString
+        self.sessionManager = sessionManager
     }
 
     // MARK: - Connection management
@@ -347,7 +345,7 @@ public class Connection: ConnectionProtocol {
         urlRequest?.timeoutInterval = timeout
 
         let encodedURLRequest = try? encoding.encode(urlRequest!, with: parameters)
-        return Alamofire.request(encodedURLRequest!)
+        return sessionManager.request(encodedURLRequest!)
     }
 
     func createUserAgentString(client: String) -> String {

--- a/SignalR-Swift/Client/Hubs/HubConnection.swift
+++ b/SignalR-Swift/Client/Hubs/HubConnection.swift
@@ -7,27 +7,21 @@
 //
 
 import Foundation
+import Alamofire
 
 public class HubConnection: Connection, HubConnectionProtocol {
 
     private var hubs = [String: HubProxy]()
     private var callbacks = [String: HubConnectionHubResultClosure]()
-    private var callbackId = 0
-
-    override public convenience init(withUrl url: String) {
-        self.init(withUrl: url, useDefault: true)
-    }
-
-    public init(withUrl url: String, useDefault: Bool) {
-        super.init(withUrl: HubConnection.getUrl(url: url, useDefault: useDefault))
-    }
-
-    override public convenience init(withUrl url: String, queryString: [String: String]?) {
-        self.init(withUrl: url, queryString: queryString, useDefault: true)
-    }
-
-    public init(withUrl url: String, queryString: [String: String]?, useDefault: Bool) {
-        super.init(withUrl: HubConnection.getUrl(url: url, useDefault: useDefault), queryString: queryString)
+    private var callbackId = UInt.min
+    
+    public init(withUrl url: String,
+                queryString: [String: String]? = nil,
+                sessionManager: SessionManager = .default,
+                useDefault: Bool = true) {
+        super.init(withUrl: HubConnection.getUrl(url: url, useDefault: useDefault),
+                   queryString: queryString,
+                   sessionManager: sessionManager)
     }
 
     public func createHubProxy(hubName: String) -> HubProxy? {
@@ -71,8 +65,7 @@ public class HubConnection: Connection, HubConnectionProtocol {
     // MARK: - Private
 
     static func getUrl(url: String, useDefault: Bool) -> String {
-        var urlResult = url
-        urlResult = url.hasSuffix("/") ? url : url.appending("/")
+        let urlResult = url.hasSuffix("/") ? url : url.appending("/")
 
         if useDefault {
             return urlResult.appending("signalr")

--- a/SignalR-Swift/Client/Protocols/ConnectionProtocol.swift
+++ b/SignalR-Swift/Client/Protocols/ConnectionProtocol.swift
@@ -24,6 +24,8 @@ public protocol ConnectionProtocol: class {
     var state: ConnectionState { get }
     var transport: ClientTransportProtocol? { get }
     var headers: HTTPHeaders { get set }
+    var sessionManager: SessionManager { get }
+    var webSocketAllowsSelfSignedSSL: Bool { get set }
 
     func onSending() -> String?
 

--- a/SignalR-Swift/Transports/HttpTransport.swift
+++ b/SignalR-Swift/Transports/HttpTransport.swift
@@ -53,7 +53,7 @@ public class HttpTransport: ClientTransportProtocol {
 
         let parameters = self.getConnectionParameters(connection: connection, connectionData: connectionData)
 
-        let encodedRequest = Alamofire.request(url, method: .get, parameters: parameters.toJSON(), encoding: URLEncoding.default, headers: nil)
+        let encodedRequest = connection.sessionManager.request(url, method: .get, parameters: parameters.toJSON(), encoding: URLEncoding.default, headers: nil)
 
         var requestParams = [String: Any]()
 

--- a/SignalR-Swift/Transports/WebSocketTransport.swift
+++ b/SignalR-Swift/Transports/WebSocketTransport.swift
@@ -134,8 +134,9 @@ public class WebSocketTransport: HttpTransport, WebSocketDelegate {
 
             if let encodedRequest = request?.request {
                 self.webSocket = WebSocket(request: encodedRequest)
-                self.webSocket?.delegate = self
-                self.webSocket?.open()
+                self.webSocket!.allowSelfSignedSSL = connection?.webSocketAllowsSelfSignedSSL ?? false
+                self.webSocket!.delegate = self
+                self.webSocket!.open()
             }
         } catch {
 


### PR DESCRIPTION
This pull request is a suggestion how possible to add a self-signed certificate support.
It would be nice to have that feature for a testing purpose.

**How to use:**

1. Create a `[Hub]Connection` instance and pass an Alamofire `SessionManader` through a class initializer. [How to connect to self-signed servers using Alamofire](https://stackoverflow.com/a/31988229).

2. Set property `webSocketAllowsSelfSignedSSL` of the `Connection` instance to `true` value.

``` Swift
let hubConnection = HubConnection(withUrl: ..., sessionManager: ...)
hubConnection.webSocketAllowsSelfSignedSSL = true
```