### PR TITLE
Heartbeat monitor & crash & refactoring 

### DIFF
--- a/SignalR-Swift/Client/Connection.swift
+++ b/SignalR-Swift/Client/Connection.swift
@@ -60,24 +60,12 @@ public class Connection: ConnectionProtocol {
 
     weak var delegate: ConnectionDelegate?
 
-    public static func connection(withUrl url: String) -> Connection {
-        return Connection(withUrl: url)
-    }
-
-    public static func connection(withUrl url: String, queryString: [String: String]?) -> Connection {
-        return Connection(withUrl: url, queryString: queryString)
-    }
-
-    static func ensureReconnecting(connection: ConnectionProtocol?) -> Bool {
-        if connection == nil {
-            return false
+    static func ensureReconnecting(connection: ConnectionProtocol) -> Bool {
+        if connection.changeState(oldState: .connected, toState: .reconnecting) {
+            connection.willReconnect()
         }
 
-        if connection!.changeState(oldState: .connected, toState: .reconnecting) {
-            connection!.willReconnect()
-        }
-
-        return connection!.state == .reconnecting
+        return connection.state == .reconnecting
     }
 
     public init(withUrl url: String, queryString: [String: String]? = nil, sessionManager: SessionManager = .default) {

--- a/SignalR-Swift/Client/Connection.swift
+++ b/SignalR-Swift/Client/Connection.swift
@@ -257,11 +257,8 @@ public class Connection: ConnectionProtocol {
     }
 
     public func willReconnect() {
-        self.disconnectTimeoutOperation = BlockOperation(block: { [unowned self] in
-            self.stopButDoNotCallServer()
-        })
-
         if let disconnectTimeout = self.disconnectTimeout {
+            self.disconnectTimeoutOperation = BlockOperation(block: { [weak self] in self?.stopButDoNotCallServer() })
             self.disconnectTimeoutOperation.perform(#selector(BlockOperation.start), with: nil, afterDelay: disconnectTimeout)
         }
 
@@ -274,7 +271,6 @@ public class Connection: ConnectionProtocol {
 
     public func didReconnect() {
         NSObject.cancelPreviousPerformRequests(withTarget: self.disconnectTimeoutOperation, selector: #selector(BlockOperation.start), object: nil)
-
         self.disconnectTimeoutOperation = nil
         
         self.reconnected?()

--- a/SignalR-Swift/Client/Hubs/HubInvocation.swift
+++ b/SignalR-Swift/Client/Hubs/HubInvocation.swift
@@ -15,15 +15,7 @@ private let kArgs = "A"
 private let kState = "S"
 
 struct HubInvocation {
-    
-    enum CodingKeys : String, CodingKey {
-        case kCallbackId = "I"
-        case kHub = "H"
-        case kMethod = "M"
-        case kArgs = "A"
-        case kState = "S"
-    }
-    
+
     let callbackId: String
     let hub: String
     let method: String

--- a/SignalR-Swift/Transports/ServerSentEventsTransport.swift
+++ b/SignalR-Swift/Transports/ServerSentEventsTransport.swift
@@ -150,9 +150,8 @@ public class ServerSentEventsTransport: HttpTransport {
     
     private func reconnect(connection: ConnectionProtocol, data: String?) {
         _ = BlockOperation { [weak self, weak connection] in
-            guard let strongSelf = self, let strongConnection = connection else { return }
-            
-            if strongConnection.state != .disconnected && Connection.ensureReconnecting(connection: strongConnection) {
+            if let strongSelf = self, let strongConnection = connection,
+               strongConnection.state != .disconnected, Connection.ensureReconnecting(connection: strongConnection) {
                 strongSelf.open(connection: strongConnection, connectionData: data, isReconnecting: true)
             }
         }.perform(#selector(BlockOperation.start), with: nil, afterDelay: self.reconnectDelay)

--- a/SignalR-Swift/Transports/WebSocketTransport.swift
+++ b/SignalR-Swift/Transports/WebSocketTransport.swift
@@ -139,10 +139,8 @@ public class WebSocketTransport: HttpTransport, WebSocketDelegate {
     }
 
     func reconnect(connection: ConnectionProtocol?) {
-        _ = BlockOperation { [weak self] () -> () in
-            guard let strongSelf = self else { return }
-
-            if Connection.ensureReconnecting(connection: connection) {
+        _ = BlockOperation { [weak self] in
+            if let strongSelf = self, let connection = connection, Connection.ensureReconnecting(connection: connection) {
                 strongSelf.performConnect(reconnecting: true, completionHandler: nil)
             }
             }.perform(#selector(BlockOperation.start), with: nil, afterDelay: self.reconnectDelay)


### PR DESCRIPTION
## A wrong logic in `HeartbeatMonitor`.
Compare the next 2 snippets:
https://github.com/AutosoftDMS/SignalR-Swift/blob/a8ded012ff2991004375e14c2de054999a1c8e51/SignalR-Swift/Client/HeartbeatMonitor.swift#L49-L50
and
https://github.com/DyKnow/SignalR-ObjC/blob/c412cc38618b27c83fe170eaa9da95aa0c7eb42a/SignalR.Client/SRHeartbeatMonitor.m#L65-L68
This is the only place that the field is set to `true`.
The same error is here
https://github.com/AutosoftDMS/SignalR-Swift/blob/a8ded012ff2991004375e14c2de054999a1c8e51/SignalR-Swift/Client/HeartbeatMonitor.swift#L54-L55

## A crash.
https://github.com/AutosoftDMS/SignalR-Swift/blob/a8ded012ff2991004375e14c2de054999a1c8e51/SignalR-Swift/Client/Connection.swift#L260-L262
The problem is the `unowned` reference 