### PR TITLE
Improved detection of line endings in ChunkBuffer

### DIFF
--- a/SignalR-Swift/Transports/ServerSentEvents/ChunkBuffer.swift
+++ b/SignalR-Swift/Transports/ServerSentEvents/ChunkBuffer.swift
@@ -23,7 +23,7 @@ final class ChunkBuffer {
     func readLine() -> String? {
         var line: String?
 
-        while let endIndex = buffer.index(of: "\n") {
+        while let endIndex = buffer.index(of: "\n") ?? buffer.index(of: "\n\r") {
             let substring = buffer[..<endIndex]
             buffer.removeSubrange(buffer.startIndex ..< buffer.index(after: endIndex))
 


### PR DESCRIPTION
Added carriage return + line feed (\n\r) as possible line endings to 'readLine()'.

Otherwise if the server delivers a response like:
`
data: {...}\n\r
data: {}
`
the response cannot be parsed correctly in 'ServerSentEventsTransport.open()'